### PR TITLE
Support Collecting CPU Cycles on aarch64, running GNU/Linux Kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@
 | ------------ | ----------- |
 | x86          | rdtsc       |
 | x86_64       | rdtsc       |
+| aarch64 (running GNU/Linux kernel)     | pmccntr     |
 | loongarch64  | rdtime.d    |
 
 > **Warning**
 This crate measures clock ticks rather than cycles. It will not provide accurate results on modern machines unless you calculate the ratio of ticks to cycles and take steps to ensure that that ratio remains consistent.
+
+> **Warning**
+In case you're planning to use this library on an `aarch64` target, running GNU/Linux kernel, I advise you to read [src/lib.rs#L61-L68](src/lib.rs#L61-L68).
 
 <br>
 

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-fn fibonacci_slow(n: usize)-> usize {
+fn fibonacci_slow(n: usize) -> usize {
     match n {
         0 => panic!("zero is not a good argument to fibonacci_slow()!"),
         1 | 2 => 1,
@@ -12,7 +12,7 @@ fn fibonacci_slow(n: usize)-> usize {
         _ => fibonacci_slow(n - 1) + fibonacci_slow(n - 2),
     }
 }
-fn fibonacci_fast(n: usize)-> usize {
+fn fibonacci_fast(n: usize) -> usize {
     if n == 0 {
         panic!("zero is not a right argument to fibonacci_fast()!");
     } else if n == 1 {
@@ -28,7 +28,6 @@ fn fibonacci_fast(n: usize)-> usize {
         current = sum;
     }
     sum
-
 }
 
 fn bench(c: &mut Criterion<CyclesPerByte>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,12 @@ use criterion::{
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
+    target_arch = "aarch64",
     target_arch = "loongarch64"
 )))]
-compile_error!("criterion-cycles-per-byte currently relies on x86 or x86_64 or loongarch64.");
+compile_error!(
+    "criterion-cycles-per-byte currently works only on x86 or x86_64 or aarch64 or loongarch64."
+);
 
 /// `CyclesPerByte` measures clock cycles using the CPU read time-stamp counter instruction. `cpb` is
 /// the preferred measurement for cryptographic algorithms.
@@ -53,15 +56,25 @@ fn rdtsc() -> u64 {
         core::arch::x86::_rdtsc()
     }
 
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    unsafe {
+        // If a aarch64 CPU, running GNU/Linux kernel, executes following instruction,
+        // it'll *probably* panic with message "illegal instruction executed", because userspace
+        // isn't allowed to execute that instruction without installing a Linux Kernel Module.
+        //
+        // I've tested the LKM @ https://github.com/jerinjacobk/armv8_pmu_cycle_counter_el0
+        // on a Raspberry Pi 4b ( i.e. ARM Cortex-A72, running kernel version 6.5.0-1006-raspi )
+        // and it works like charm. While extending support of this library for aarch64 targets,
+        // I found https://github.com/pornin/crrl#benchmarks pretty helpful.
+        let mut counter: u64;
+        core::arch::asm!("dsb sy", "mrs {}, pmccntr_el0", out(reg) counter);
+        counter
+    }
+
     #[cfg(target_arch = "loongarch64")]
     unsafe {
         let counter: u64;
-
-        core::arch::asm!(
-            "rdtime.d {0}, $zero",
-            out(reg) counter,
-        );
-
+        core::arch::asm!("rdtime.d {0}, $zero", out(reg) counter);
         counter
     }
 }
@@ -138,7 +151,7 @@ impl ValueFormatter for CyclesPerByteFormatter {
                     *val /= *n as f64;
                 }
                 "cpb (decimal)"
-            },
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds support for collecting CPU cycles using **PMCCTR** on `aarch64` targets, running GNU/Linux kernel. 

For example of it being used, see https://github.com/itzmeanjan/turboshake/blob/72882b5a3c6bd27918ccead41a8681777c405b37/benches/turboshake.rs
For benchmark results collected, see https://github.com/itzmeanjan/turboshake#on-arm-cortex-a72-raspberry-pi-4b