### PR TITLE
Add `rdpru` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ repository = "https://github.com/wainwrightmark/criterion-cycles-per-byte"
 
 [dependencies]
 criterion = "0.5"
-
+cfg-if = "1"
 
 [[bench]]
 name = "fibonacci"
 harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rdpru)'] }

--- a/README.md
+++ b/README.md
@@ -7,39 +7,52 @@
 
 `CyclesPerByte` measures ticks using the CPU read time-stamp counter instruction.
 
-| Architecture | Instruction |
-| ------------ | ----------- |
-| x86          | rdtsc       |
-| x86_64       | rdtsc       |
+## Cycle measurement instructions
+
+| Architecture |  Instruction  |
+| ------------ | ------------- |
+| x86          | rdtsc / rdpru |
+| x86_64       | rdtsc / rdpru |
 | aarch64 (running GNU/Linux kernel)     | pmccntr     |
-| loongarch64  | rdtime.d    |
+| loongarch64  | rdtime.d      |
 
-> **Warning**
-This crate measures clock ticks rather than cycles. It will not provide accurate results on modern machines unless you calculate the ratio of ticks to cycles and take steps to ensure that that ratio remains consistent.
+The RDPRU instruction is available only on AMD CPUs since Zen 2 and it is not used by default.
+To enable it use the `rdpru` configuration flag, e.g. by using `RUSTFLAGS="--cfg rdpru"`.
+Note that this crate does not check availability of the instruction at runtime,
+which may result in the "illegal instruction" exception during benchmark execution.
 
-> **Warning**
-In case you're planning to use this library on an `aarch64` target, running GNU/Linux kernel, I advise you to read [src/lib.rs#L61-L68](src/lib.rs#L61-L68).
+After enabling `rdpru` it is also strongly recommended to pin benchmarks to one core, e.g. by using
+`taskset`: `RUSTFLAGS="--cfg rdpru" taskset --cpu-list 0 cargo bench`. Otherwise, the crate may
+produce wildly incorrect measurments caused by benchmark thread migration across CPU cores.
 
-<br>
+### Warnings: x86
 
+Unless `rdpru` is enabled, this crate measures clock ticks rather than cycles.
+It will not provide accurate results on modern machines unless you calculate the ratio of ticks
+to cycles and take steps to ensure that that ratio remains consistent.
+
+### Warnings: aarch64
+
+In case you're planning to use this library on an `aarch64` target, running GNU/Linux kernel,
+I advise you to read [src/lib.rs#L61-L68](src/lib.rs#L61-L68).
+
+## Example
 
 ```rust
-# fn fibonacci_slow(_: usize) {}
-# fn fibonacci_fast(_: usize) {}
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use criterion_cycles_per_byte::CyclesPerByte;
-//!
+
 fn bench(c: &mut Criterion<CyclesPerByte>) {
     let mut group = c.benchmark_group("fibonacci");
-//!
+
     for i in 0..20 {
         group.bench_function(BenchmarkId::new("slow", i), |b| b.iter(|| fibonacci_slow(i)));
         group.bench_function(BenchmarkId::new("fast", i), |b| b.iter(|| fibonacci_fast(i)));
     }
-//!
+
     group.finish()
 }
-//!
+
 criterion_group!(
     name = my_bench;
     config = Criterion::default().with_measurement(CyclesPerByte);
@@ -48,10 +61,11 @@ criterion_group!(
 criterion_main!(my_bench);
 ```
 
-<br>
+## Maintainence status
 
-> **Note**
-I am not the original writer but am maintaining this crate because it is still being used in several places. I plan to do version updates and bug fixes as necessary but not to add features or attempt fix the (potentially intractable)  problems with this method of measurement.
+I am not the original writer but am maintaining this crate because it is still being used
+in several places. I plan to do version updates and bug fixes as necessary but not to add
+features or attempt fix the (potentially intractable) problems with this method of measurement.
 
 
 ## Compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,54 +30,64 @@ use criterion::{
     Throughput,
 };
 
-#[cfg(not(any(
-    target_arch = "x86_64",
-    target_arch = "x86",
-    target_arch = "aarch64",
-    target_arch = "loongarch64"
-)))]
-compile_error!(
-    "criterion-cycles-per-byte currently works only on x86 or x86_64 or aarch64 or loongarch64."
-);
-
 /// `CyclesPerByte` measures clock cycles using the CPU read time-stamp counter instruction. `cpb` is
 /// the preferred measurement for cryptographic algorithms.
 pub struct CyclesPerByte;
 
 // WARN: does not check for the cpu feature; but we'd panic anyway so...
-fn rdtsc() -> u64 {
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::x86_64::_mm_mfence();
-        core::arch::x86_64::_rdtsc()
-    }
-
+#[inline(always)]
+fn cycle_counter() -> u64 {
     #[cfg(target_arch = "x86")]
-    unsafe {
-        core::arch::x86::_mm_mfence();
-        core::arch::x86::_rdtsc()
-    }
+    use core::arch::x86::*;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::*;
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     unsafe {
-        // If a aarch64 CPU, running GNU/Linux kernel, executes following instruction,
-        // it'll *probably* panic with message "illegal instruction executed", because userspace
-        // isn't allowed to execute that instruction without installing a Linux Kernel Module.
-        //
-        // I've tested the LKM @ https://github.com/jerinjacobk/armv8_pmu_cycle_counter_el0
-        // on a Raspberry Pi 4b ( i.e. ARM Cortex-A72, running kernel version 6.5.0-1006-raspi )
-        // and it works like charm. While extending support of this library for aarch64 targets,
-        // I found https://github.com/pornin/crrl#benchmarks pretty helpful.
-        let mut counter: u64;
-        core::arch::asm!("dsb sy", "mrs {}, pmccntr_el0", out(reg) counter);
-        counter
-    }
-
-    #[cfg(target_arch = "loongarch64")]
-    unsafe {
-        let counter: u64;
-        core::arch::asm!("rdtime.d {0}, $zero", out(reg) counter);
-        counter
+        cfg_if::cfg_if! {
+            if #[cfg(all(rdpru, any(target_arch = "x86_64", target_arch = "x86")))] {
+                // `LFENCE`s stop RDPRU speculation
+                let [hi, lo]: [u32; 2];
+                _mm_lfence();
+                core::arch::asm!(
+                    "rdpru",
+                    out("edx") hi,
+                    out("eax") lo,
+                    in("ecx") 1u32,
+                    options(nostack, nomem, preserves_flags),
+                );
+                let ret = (u64::from(hi) << 32) | u64::from(lo);
+                _mm_lfence();
+                ret
+            } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+                // `LFENCE`s stop RDPRU speculation. Note that MFENCE is not needed here
+                // for reasons stated in this Linux commit message:
+                // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=be261ffce6f1
+                _mm_lfence();
+                let ret = _rdtsc();
+                _mm_lfence();
+                ret
+            } else if #[cfg(all(target_arch = "aarch64", target_os = "linux"))] {
+                // If a aarch64 CPU, running GNU/Linux kernel, executes following instruction,
+                // it'll *probably* panic with message "illegal instruction executed", because userspace
+                // isn't allowed to execute that instruction without installing a Linux Kernel Module.
+                //
+                // I've tested the LKM @ https://github.com/jerinjacobk/armv8_pmu_cycle_counter_el0
+                // on a Raspberry Pi 4b ( i.e. ARM Cortex-A72, running kernel version 6.5.0-1006-raspi )
+                // and it works like charm. While extending support of this library for aarch64 targets,
+                // I found https://github.com/pornin/crrl#benchmarks pretty helpful.
+                let counter: u64;
+                core::arch::asm!("dsb sy", "mrs {}, pmccntr_el0", out(reg) counter);
+                counter
+            } else if #[cfg(target_arch = "loongarch64")] {
+                let counter: u64;
+                core::arch::asm!("rdtime.d {0}, $zero", out(reg) counter);
+                counter
+            } else {
+                compile_error!(
+                    "criterion-cycles-per-byte currently works only on x86 or x86_64 or aarch64 or loongarch64."
+                );
+            }
+        }
     }
 }
 
@@ -85,22 +95,27 @@ impl Measurement for CyclesPerByte {
     type Intermediate = u64;
     type Value = u64;
 
+    #[inline]
     fn start(&self) -> Self::Intermediate {
-        rdtsc()
+        cycle_counter()
     }
 
+    #[inline]
     fn end(&self, i: Self::Intermediate) -> Self::Value {
-        rdtsc().saturating_sub(i)
+        cycle_counter().saturating_sub(i)
     }
 
+    #[inline]
     fn add(&self, v1: &Self::Value, v2: &Self::Value) -> Self::Value {
         v1 + v2
     }
 
+    #[inline]
     fn zero(&self) -> Self::Value {
         0
     }
 
+    #[inline]
     fn to_f64(&self, value: &Self::Value) -> f64 {
         *value as f64
     }


### PR DESCRIPTION
The RDPRU support is gated behind `rdpru` configuration flag.

It should be possible it implement runtime detection of RDPRU availability using CPUID, but since this crate does not bother doing it for RDTSC, I left it for a potential later PR. Plus it would introduce additional overhead to measurement.

This PR additionally improves code a bit by using `cfg-if` and adding `#[inline]` attributes to allow cross-crate inlining of the methods without relying on LTO.

Closes #1 