### PR TITLE
Add riscv64 support with rdtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | x86_64       | rdtsc / rdpru |
 | aarch64 (running GNU/Linux kernel)     | pmccntr     |
 | loongarch64  | rdtime.d      |
+| riscv64      | rdtime        |
 
 The RDPRU instruction is available only on AMD CPUs since Zen 2 and it is not used by default.
 To enable it use the `rdpru` configuration flag, e.g. by using `RUSTFLAGS="--cfg rdpru"`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,13 @@ fn cycle_counter() -> u64 {
                 let counter: u64;
                 core::arch::asm!("rdtime.d {0}, $zero", out(reg) counter);
                 counter
+            } else if #[cfg(target_arch = "riscv64")] {
+                let counter: u64;
+                core::arch::asm!("rdtime {0}", out(reg) counter);
+                counter
             } else {
                 compile_error!(
-                    "criterion-cycles-per-byte currently works only on x86 or x86_64 or aarch64 or loongarch64."
+                    "criterion-cycles-per-byte currently works only on x86 or x86_64 or aarch64 or loongarch64 or riscv64."
                 );
             }
         }


### PR DESCRIPTION
Starting with Linux 6.6 [1], RDCYCLE is a privileged instruction on RISC-V and can't be used directly from userland. There is a sysctl option to change that as a transition period, but it will eventually disappear.

Use RDTIME instead, which while less accurate has the advantage of being synchronized between CPU (and thus monotonic) and of constant frequency.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=cc4c07c89aada16229084eeb93895c95b7eabaa3

Tested on real riscv64 machine with `cargo bench`.
Some random output snippet:

```text
fibonacci/slow/7        time:   [3.1978 cycles 3.2037 cycles 3.2111 cycles]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe
fibonacci/fast/7        time:   [0.4788 cycles 0.4793 cycles 0.4800 cycles]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
fibonacci/slow/8        time:   [5.6673 cycles 5.7095 cycles 5.7829 cycles]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
fibonacci/fast/8        time:   [0.5680 cycles 0.5758 cycles 0.5843 cycles]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
fibonacci/slow/9        time:   [9.5699 cycles 9.5847 cycles 9.5992 cycles]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
fibonacci/fast/9        time:   [0.8341 cycles 0.8546 cycles 0.8754 cycles]
fibonacci/slow/10       time:   [15.5702 cycles 15.5936 cycles 15.6201 cycles]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```